### PR TITLE
Fixing issue causing preventing pwgen and dumb-init from being installed in CentOS image

### DIFF
--- a/centos/Dockerfile
+++ b/centos/Dockerfile
@@ -59,8 +59,12 @@ LABEL name="xebialabs/xl-deploy" \
       url="https://www.xebialabs.com/xl-deploy"
 
 # Install dependencies
-RUN yum update && \
-    yum install -y dumb-init java-1.8.0-openjdk-headless pwgen
+RUN yum update -y && \
+    yum install -y epel-release && \
+    yum install -y java-1.8.0-openjdk-headless pwgen python-pip && \
+    yum clean all
+
+RUN pip install dumb-init
 
 ENV USER_NAME=xl-deploy USER_UID=10001 APP_ROOT=/opt
 ENV APP_HOME=/opt/xl-deploy-server


### PR DESCRIPTION
As-is, both `pwgen` and `dumb-init` are not installed. `pwgen` requires the `epel-release` repo and `dumb-init` is not available via the typical `yum` repos, so installing `dumb-init` via `pip`.

Also tossed in a `yum clean all` in the hopes of keeping the overall image size down (haven't looked to see what the actual delta is, though).